### PR TITLE
Enable possibility to user control $CGIBASHOPTS_DIR

### DIFF
--- a/cgibashopts
+++ b/cgibashopts
@@ -10,7 +10,9 @@ export FORMS=
 export FORMFILES=
 export FORMQUERY=
 if [ x"$1" != x-n ]; then
-    export CGIBASHOPTS_DIR=/tmp/cgibashopts-files.$$
+    if [ -z $CGIBASHOPTS_DIR ]; then
+        export CGIBASHOPTS_DIR=/tmp/cgibashopts-files.$$
+    fi
     CGIBASHOPTS_TMP="$CGIBASHOPTS_DIR.tmp"
     cgibashopts_clean() { 
 	[ -n "$CGIBASHOPTS_DIR" ] && [ -d "$CGIBASHOPTS_DIR" ] && rm -rf "$CGIBASHOPTS_DIR"


### PR DESCRIPTION
The default directory /tmp for $CGIBASHOPTS_DIR is often on a different partition than the root filesystem. So moving a file from /tmp to the root filesystem might take some time. This PR enables the possibility to control where $CGIBASHOPTS_DIR points to.
